### PR TITLE
Add test for determinism & deterministic iteration

### DIFF
--- a/base.py
+++ b/base.py
@@ -3,6 +3,7 @@ import datetime
 import itertools
 from config import TICK_MINUTE
 from utils import compute_distance
+from orderedset import OrderedSet
 
 class Env(simpy.Environment):
 
@@ -59,7 +60,7 @@ class Location(simpy.Resource):
     def __init__(self, env, capacity=simpy.core.Infinity, name='Safeway', location_type='stores', lat=None, lon=None,
                  area=None, cont_prob=None):
         super().__init__(env, capacity)
-        self.humans = set()
+        self.humans = OrderedSet() #OrderedSet instead of set for determinism when iterating
         self.name = name
         self.lat = lat
         self.lon = lon

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy==1.18.2
 matplotlib==3.2.1
 ipython==7.13.0
 click==7.1.1
-
+orderedset==2.0.3

--- a/run.py
+++ b/run.py
@@ -5,7 +5,7 @@ import datetime
 import click
 from config import TICK_MINUTE
 import numpy as np
-
+import math
 
 @click.group()
 def simu():
@@ -91,6 +91,7 @@ def run_simu(n_stores=None, n_people=None, n_parks=None, n_misc=None,
 
     if Human is None:
         from simulator import Human
+
     rng = np.random.RandomState(seed)
     env = Env(start_time)
     city_limit = ((0, 1000), (0, 1000))
@@ -98,8 +99,8 @@ def run_simu(n_stores=None, n_people=None, n_parks=None, n_misc=None,
     area_dict = {'store':_get_random_area('store', n_stores, total_area, rng), 
                  'park':_get_random_area('park',n_parks, total_area, rng),
                  'misc':_get_random_area('misc',n_misc, total_area, rng),
-                 'household':_get_random_area('household', int(n_people/2), total_area, rng),
-                 'workplace':_get_random_area('workplace', int(n_people/30), total_area, rng)}
+                 'household':_get_random_area('household', math.ceil(n_people/2), total_area, rng),
+                 'workplace':_get_random_area('workplace', math.ceil(n_people/30), total_area, rng)}
     
     stores = [
         Location(
@@ -133,7 +134,7 @@ def run_simu(n_stores=None, n_people=None, n_parks=None, n_misc=None,
             lat=rng.randint(*city_limit[0]),
             lon=rng.randint(*city_limit[1]),
         )
-        for i in range(int(n_people / 2))
+        for i in range(math.ceil(n_people / 2))
     ]
     workplaces = [
         Location(
@@ -144,7 +145,7 @@ def run_simu(n_stores=None, n_people=None, n_parks=None, n_misc=None,
             lat=rng.randint(*city_limit[0]),
             lon=rng.randint(*city_limit[1]),
         )
-        for i in range(int(n_people / 30))
+        for i in range(math.ceil(n_people / 30))
     ]
     miscs = [
         Location(

--- a/simulator.py
+++ b/simulator.py
@@ -172,16 +172,6 @@ class Human(object):
                 return None
 
     @property
-    def reported_symptoms(self):
-        if self.symptoms is None or self.test_results is None or not self.human.has_app:
-            return None
-        else:
-            if self.rng.rand() < self.carefullness:
-                return self.symptoms
-            else:
-                return None
-
-    @property
     def symptoms(self):
         # probability of being asymptomatic is basically 50%, but a bit less if you're older
         # and a bit more if you're younger


### PR DESCRIPTION
## Working towards getting a deterministic simulation.

Implemented a test to check determinism. Before this commit, we had no determinism, even for small simulation (i.e. 3 people, 1 day). This is checked by running two simulations and comparing the output file, as implemented in the new test "test_sim_same_seed". One of the problem was traced to be the iteration over a Set, which is not guaranteed to be deterministic. By changing to an OrderedSet, we can guarantee that the iteration will happen in the same way for each run.

# Changes
* Uses OrderedSet instead of Set for location.humans
* Use Math.ceil instead of typacasting to ensure that humans always have a household and a workplace (otherwise, a small number for humans gets rounded to zero household and zero workplace, yielding an error). This enables the simulation for any number of humans, while we were limited to have >30 humans
* Removed duplicated function in code before the duplicated code diverges and cause problems
* Added first test for determinism

# Note
The test is currently skipped since determinism is not implemented everywhere yet. I will submit more PR once I figure out what is causing the test to fail sometime it higher values of days or people