### PR TITLE
Fix argument order for log_test and log_symptom_start. 

### DIFF
--- a/base.py
+++ b/base.py
@@ -174,7 +174,7 @@ class Event:
         )
 
     @staticmethod
-    def log_symptom_start(human, time, covid=True):
+    def log_symptom_start(human, covid, time):
         human.events.append(
             {
                 'human_id': human.name,

--- a/simulator.py
+++ b/simulator.py
@@ -291,12 +291,12 @@ class Human(object):
         while True:
 
             if self.is_infectious and self.has_logged_symptoms is False:
-                Event.log_symptom_start(self, self.env.timestamp, True)
+                Event.log_symptom_start(self, True, self.env.timestamp)
                 self.has_logged_symptoms = True
 
             if self.is_infectious and self.env.timestamp - self.infection_timestamp > datetime.timedelta(days=TEST_DAYS) and not self.has_logged_test:
                 result = self.rng.random() > 0.8
-                Event.log_test(self, self.env.timestamp, result)
+                Event.log_test(self, result, self.env.timestamp)
                 self.has_logged_test = True
                 assert self.has_logged_symptoms is True # FIXME: assumption might not hold
 

--- a/toy.py
+++ b/toy.py
@@ -27,7 +27,7 @@ class Event:
         pass
 
     @staticmethod
-    def log_symptom_start(human, time, covid=True):
+    def log_symptom_start(human, covid, time):
         pass
 
     @staticmethod
@@ -140,11 +140,11 @@ class Human(object):
                     self.last_state = self.state
 
             if self.is_infectious and self.has_logged_symptoms is False:
-                Event.log_symptom_start(self, self.env.timestamp, True)
+                Event.log_symptom_start(self, True, self.env.timestamp)
                 self.has_logged_symptoms = True
 
             if self.is_infectious and self.env.timestamp - self.infection_timestamp > datetime.timedelta(days=TEST_DAYS):
-                Event.log_test(self, self.env.timestamp, True)
+                Event.log_test(self, True, self.env.timestamp)
                 assert self.has_logged_symptoms is True
 
             if self.is_infectious and self.env.timestamp - self.infection_timestamp >= datetime.timedelta(days=AVG_RECOVERY_DAYS):


### PR DESCRIPTION
Made them consistent with the other logging functions (timestamp as last argument).

Before, the error was causing test result and time to be switched.