### PR TITLE
added templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md.py
+++ b/.github/ISSUE_TEMPLATE.md.py
@@ -1,0 +1,31 @@
+# Prerequisites
+
+Please answer the following questions for yourself before submitting an issue. **YOU MAY DELETE THE PREREQUISITES SECTION.**
+
+- [ ] I am running the latest version
+- [ ] I checked the documentation and found no answer
+- [ ] I checked to make sure that this issue has not already been filed
+
+# Expected Behavior
+
+Please describe the behavior you are expecting
+
+# Current Behavior
+
+What is the current behavior?
+
+# Failure Information (for bugs)
+
+Please help provide information about the failure if this is a bug. If it is not a bug, please remove the rest of this template.
+
+## Steps to Reproduce
+
+Please provide detailed steps for reproducing the issue.
+
+1. step 1
+2. step 2
+3. you get it...
+
+## Failure Logs
+
+Please include any relevant log snippets or files here.

--- a/.github/PULL_REQUEST_TEMPLATE.md.py
+++ b/.github/PULL_REQUEST_TEMPLATE.md.py
@@ -1,0 +1,31 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
This PR adds a couple templates to a hidden .github folder. These templates will populate the PR space (which I'm currently writing) and the issue space. It should help people write good PRs and issues by giving them some reminders and questions.

More information about PR and Issue templates on github is available here: https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository

