### PR TITLE
Bump minimum python version req to 3.7

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ['3.6', '3.7', '3.8']
+        python_version: ['3.7', '3.8']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We plan to update the simulator as more and more about COVID-19 will be known.
 
 
 ## Dependencies
-Following `python` packages are required (python>=3.6)
+Following `python` packages are required (python>=3.7)
 ```
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
Moving away from Python 3.6 may reduce potential issues with set/dictionary ordering. It should also allow the use of dataclasses instead of namedtuples, which may come in handy for future refactoring.