### PR TITLE
risk updates were not appt

### DIFF
--- a/src/covid19sim/interventions.py
+++ b/src/covid19sim/interventions.py
@@ -363,9 +363,10 @@ class Tracing(object):
             for human in city.humans:
                 cur_day = (human.env.timestamp - human.env.initial_timestamp).days
                 if (human.env.timestamp - human.message_info['receipt']).days >= human.message_info['delay'] or self.risk_model != "manual":
-                    if not human.is_removed and human.test_result != "positive"::
+                    if not human.is_removed and human.test_result != "positive":
                         t, s, r = self.process_messages(human)
                         human.risk = self.compute_risk(t, s, r)
+
                     human.risk_history_map[cur_day] = human.risk
 
                     human.update_risk_level()

--- a/src/covid19sim/interventions.py
+++ b/src/covid19sim/interventions.py
@@ -363,8 +363,9 @@ class Tracing(object):
             for human in city.humans:
                 cur_day = (human.env.timestamp - human.env.initial_timestamp).days
                 if (human.env.timestamp - human.message_info['receipt']).days >= human.message_info['delay'] or self.risk_model != "manual":
-                    t, s, r = self.process_messages(human)
-                    human.risk = self.compute_risk(t, s, r)
+                    if not human.is_removed:
+                        t, s, r = self.process_messages(human)
+                        human.risk = max(self.compute_risk(t, s, r), human.risk)
                     human.risk_history_map[cur_day] = human.risk
 
                     human.update_risk_level()
@@ -381,7 +382,7 @@ class Tracing(object):
         if self.risk_model == "transformer":
             return f"Tracing: {self.risk_model}"
 
-        return f"Tracing: {self.risk_model} order {self.max_depth} symptoms: {self.propagate_symptoms} risk: {self.propagate_risk}"
+        return f"Tracing: {self.risk_model} order {self.max_depth} symptoms: {self.propagate_symptoms} risk: {self.propagate_risk} modify:{self.should_modify_behavior}"
 
 
 class CityInterventions(object):

--- a/src/covid19sim/interventions.py
+++ b/src/covid19sim/interventions.py
@@ -363,9 +363,9 @@ class Tracing(object):
             for human in city.humans:
                 cur_day = (human.env.timestamp - human.env.initial_timestamp).days
                 if (human.env.timestamp - human.message_info['receipt']).days >= human.message_info['delay'] or self.risk_model != "manual":
-                    if not human.is_removed:
+                    if not human.is_removed and human.test_result != "positive"::
                         t, s, r = self.process_messages(human)
-                        human.risk = max(self.compute_risk(t, s, r), human.risk)
+                        human.risk = self.compute_risk(t, s, r)
                     human.risk_history_map[cur_day] = human.risk
 
                     human.update_risk_level()

--- a/src/covid19sim/simulator.py
+++ b/src/covid19sim/simulator.py
@@ -622,11 +622,9 @@ class Human(object):
                 city.tracker.track_generation_times(self.name) # it doesn't count environmental infection or primary case or asymptomatic/presymptomatic infections; refer the definition
 
             # log test
-            # TODO: needs better conditions; log test based on some condition on symptoms
-            if self.test_recommended or  \
-                (self.is_incubated and
-                self.test_result != "positive" and
-                self.env.timestamp - self.symptom_start_time >= datetime.timedelta(days=TEST_DAYS)):
+            if (self.test_result != "positive" and
+                (self.test_recommended or
+                (self.is_incubated and self.env.timestamp - self.symptom_start_time >= datetime.timedelta(days=TEST_DAYS)))):
                 # make testing a function of age/hospitalization/travel
                 if self.get_tested(city):
                     Event.log_test(self, self.env.timestamp)
@@ -637,7 +635,10 @@ class Human(object):
             # recover
             if self.is_infectious and self.days_since_covid >= self.recovery_days:
                 city.tracker.track_recovery(self.n_infectious_contacts, self.recovery_days)
-                self.infection_timestamp = None # indicates they are no longer infected
+
+                self.test_result, self.test_result_type = None, None
+                self.infection_timestamp = None
+
                 if self.never_recovers:
                     self.recovered_timestamp = datetime.datetime.max
                     self.dead = True
@@ -652,7 +653,6 @@ class Human(object):
                     self.dead = False
 
                 self.update_risk(recovery=True)
-                self.infection_timestamp = None # indicates they are no longer infected
                 self.all_symptoms, self.covid_symptoms = [], []
                 Event.log_recovery(self, self.env.timestamp, self.dead)
                 if self.dead:
@@ -1135,11 +1135,15 @@ class Human(object):
 
     @property
     def risk(self):
+        if not self.risk_history_map:
+            return BASELINE_RISK_VALUE
+
         cur_day = (self.env.timestamp - self.env.initial_timestamp).days
         if cur_day in self.risk_history_map:
             return self.risk_history_map[cur_day]
         else:
-            return BASELINE_RISK_VALUE
+            last_day = max(self.risk_history_map.keys())
+            return self.risk_history_map[last_day]
 
     @property
     def risk_level(self):
@@ -1186,23 +1190,22 @@ class Human(object):
             return
         cur_day = (self.env.timestamp - self.env.initial_timestamp).days
 
-        if self.tracing:
-            if recovery:
-                if self.is_removed:
-                    self.risk = 0.0
-                else:
-                    self.risk = BASELINE_RISK_VALUE
-                self.update_risk_level()
-                self.prev_risk_history_map[cur_day] = self.risk_history_map[cur_day]
+        if recovery:
+            if self.is_removed:
+                self.risk = 0.0
+            else:
+                self.risk = BASELINE_RISK_VALUE
+            self.update_risk_level()
+            self.prev_risk_history_map[cur_day] = self.risk_history_map[cur_day]
 
-            if test_results:
-                if self.test_result == "positive":
-                    self.risk = 1.0
-                    self.contact_book.send_message(self, self.tracing_method, order=1, reason="test")
-                elif self.test_result == "negative":
-                    self.risk = .2
-                self.update_risk_level()
-                self.prev_risk_history_map[cur_day] = self.risk_history_map[cur_day]
+        if test_results:
+            if self.test_result == "positive":
+                self.risk = 1.0
+                self.contact_book.send_message(self, self.tracing_method, order=1, reason="test")
+            elif self.test_result == "negative":
+                self.risk = .2
+            self.update_risk_level()
+            self.prev_risk_history_map[cur_day] = self.risk_history_map[cur_day]
 
         if symptoms and self.tracing_method.propagate_symptoms:
             if sum(x in symptoms for x in ['severe', 'trouble_breathing']) > 0 and not self.has_logged_symptoms:


### PR DESCRIPTION
# Description
**tagging relevant people to notify of possible bugs**

- Without the if clause of `test_results` in this PR, `human` could get tested twice and obtain a negative test_result the second time. 
- Without the extra lines in `human.risk` , there is a chance that `human.risk` is 1.0 at 23h and 0.01 at 24h because `cur_day` is not in there ( I think it should ideally be a list since keys are acting like index here)
- without the `max` in `interventions.py`, `human.risk` can be 0 even if the `human.test_result` is `positive`. 

- ~**Open issue**~ - Currently, risk can only go up. This is not what we want because when my past 14 days contacts are `0` I should be able to bring down my risk to 0. This can't happen as of now.
- This is addressed by not letting `risk` to change when (a) `self.is_removed` (b) `self.test_result` is `positive`. 