### PR TITLE
Fixup refactored clustering encounters in confmat & embeddings (develop)

### DIFF
--- a/plots/plot_clustering_confmat.py
+++ b/plots/plot_clustering_confmat.py
@@ -56,14 +56,13 @@ for time_step, (ref_pickle_path, pred_pickle_path) in \
                 continue
             # we will now create a set of all encounters for this bob (across all clusters)
             real_contacts = [e[0] for e in ref_encounters if e[0]._sender_uid == uid]
-            real_contact_timestamps = set([e.encounter_time for e in real_contacts])
             # the length of the set is the first quantity we need for the metric
             # (i.e. how many recent encounters 'bob' has truly had with alice)
-            real_contact_occurrences = len(real_contact_timestamps)
+            real_contact_occurrences = len(real_contacts)
             # now let's find out how many times the clustering algo though we met that bob
             pred_cluster = next((c for c in pred_cluster_mgr.clusters if c.cluster_id == cluster_id), None)
             assert pred_cluster is not None
-            pred_contact_occurrences = len(pred_cluster.get_timestamps())
+            pred_contact_occurrences = pred_cluster.get_encounter_count()
             data_hash = data_hash_base + f"+encounter:{encounter_idx}"
             data_points[data_hash] = {
                 "real_contact_occurrences": real_contact_occurrences,
@@ -86,8 +85,8 @@ for p in data_points.values():
 fig = px.imshow(
     heatmap_data,
     labels=dict(
-        x=f"Predicted number of days encountered over past {max_contact_count} days",
-        y=f"Real number of days encountered over past {max_contact_count} days",
+        x=f"Predicted number of contacts over past {max_contact_count} days",
+        y=f"Real number of contacts over past {max_contact_count} days",
         color="Count"
     ),
     x=[str(n) for n in range(1, max_contact_count + 1)],

--- a/src/covid19sim/frozen/clustering/base.py
+++ b/src/covid19sim/frozen/clustering/base.py
@@ -75,6 +75,10 @@ class ClusterBase:
         """Returns the list of timestamps for which this cluster possesses at least one encounter."""
         raise NotImplementedError
 
+    def get_encounter_count(self) -> int:
+        """Returns the number of encounters aggregated inside this cluster."""
+        raise NotImplementedError
+
 
 class ClusterManagerBase:
     """Manages message cluster creation and updates.

--- a/src/covid19sim/frozen/clustering/blind.py
+++ b/src/covid19sim/frozen/clustering/blind.py
@@ -357,7 +357,8 @@ class BlindClusterManager(ClusterManagerBase):
             cluster_embeds = collections.defaultdict(list)
             for cluster in self.clusters:
                 embed = cluster.get_cluster_embedding(
-                    current_timestamp=self.latest_refresh_timestamp,
+                    current_timestamp=cluster.latest_update_time if self.generate_backw_compat_embeddings
+                    else self.latest_refresh_timestamp,
                     include_cluster_id=True,
                     old_compat_mode=self.generate_backw_compat_embeddings,
                 )

--- a/src/covid19sim/frozen/clustering/blind.py
+++ b/src/covid19sim/frozen/clustering/blind.py
@@ -362,7 +362,8 @@ class BlindClusterManager(ClusterManagerBase):
                     include_cluster_id=True,
                     old_compat_mode=self.generate_backw_compat_embeddings,
                 )
-                cluster_embeds[cluster.latest_update_time].append([*embed, cluster.latest_update_time])
+                cluster_embeds[cluster.latest_update_time].append(
+                    [*embed, cluster.latest_update_time])
             flat_output = []
             for timestamp in sorted(cluster_embeds.keys()):
                 flat_output.extend(cluster_embeds[timestamp])
@@ -379,9 +380,8 @@ class BlindClusterManager(ClusterManagerBase):
         if self.generate_embeddings_by_timestamp:
             cluster_flags = collections.defaultdict(list)
             for cluster in self.clusters:
-                flags = cluster._get_cluster_exposition_flag()
-                for msg in cluster.messages:
-                    cluster_flags[msg.encounter_time].append(flags)
+                cluster_flags[cluster.latest_update_time].append(
+                    cluster._get_cluster_exposition_flag())
             flat_output = []
             for timestamp in sorted(cluster_flags.keys()):
                 flat_output.extend(cluster_flags[timestamp])

--- a/src/covid19sim/frozen/clustering/blind.py
+++ b/src/covid19sim/frozen/clustering/blind.py
@@ -231,6 +231,10 @@ class BlindCluster(ClusterBase):
         """Returns the list of timestamps for which this cluster possesses at least one encounter."""
         return [self.first_update_time]  # this impl's clusters always only cover a single timestamp
 
+    def get_encounter_count(self) -> int:
+        """Returns the number of encounters aggregated inside this cluster."""
+        return len(self.messages)
+
 
 class BlindClusterManager(ClusterManagerBase):
     """Manages message cluster creation and updates.

--- a/src/covid19sim/frozen/clustering/naive.py
+++ b/src/covid19sim/frozen/clustering/naive.py
@@ -320,10 +320,6 @@ class NaiveCluster(ClusterBase):
         self._real_encounter_times.extend(cluster._real_encounter_times)
         self._unclustered_messages.extend(cluster._unclustered_messages)
 
-    def get_encounter_count(self):
-        """Returns the total number of encounters aggregated into this cluster."""
-        return sum([len(m) for m in self.messages_by_timestamp.values()])
-
     def get_cluster_embedding(
             self,
             current_timestamp: TimestampType,
@@ -368,6 +364,10 @@ class NaiveCluster(ClusterBase):
     def get_timestamps(self) -> typing.List[TimestampType]:
         """Returns the list of timestamps for which this cluster possesses at least one encounter."""
         return list(self.messages_by_timestamp.keys())
+
+    def get_encounter_count(self) -> int:
+        """Returns the number of encounters aggregated inside this cluster."""
+        return sum([len(msgs) for msgs in self.messages_by_timestamp.values()])
 
 
 class NaiveClusterManager(ClusterManagerBase):

--- a/src/covid19sim/frozen/clustering/simple.py
+++ b/src/covid19sim/frozen/clustering/simple.py
@@ -136,6 +136,10 @@ class SimpleCluster(ClusterBase):
         """Returns the list of timestamps for which this cluster possesses at least one encounter."""
         return [self.first_update_time]  # this impl's clusters always only cover a single timestamp
 
+    def get_encounter_count(self) -> int:
+        """Returns the number of encounters aggregated inside this cluster."""
+        return len(self.messages)
+
 
 class SimplisticClusterManager(ClusterManagerBase):
     """Manages message cluster creation and updates.

--- a/src/covid19sim/frozen/clustering/simple.py
+++ b/src/covid19sim/frozen/clustering/simple.py
@@ -228,7 +228,8 @@ class SimplisticClusterManager(ClusterManagerBase):
                     include_cluster_id=True,
                     old_compat_mode=self.generate_backw_compat_embeddings,
                 )
-                cluster_embeds[cluster.latest_update_time].append([*embed, cluster.latest_update_time])
+                cluster_embeds[cluster.latest_update_time].append(
+                    [*embed, cluster.latest_update_time])
             flat_output = []
             for timestamp in sorted(cluster_embeds.keys()):
                 flat_output.extend(cluster_embeds[timestamp])
@@ -245,9 +246,8 @@ class SimplisticClusterManager(ClusterManagerBase):
         if self.generate_embeddings_by_timestamp:
             cluster_flags = collections.defaultdict(list)
             for cluster in self.clusters:
-                flags = cluster._get_cluster_exposition_flag()
-                for msg in cluster.messages:
-                    cluster_flags[msg.encounter_time].append(flags)
+                cluster_flags[cluster.latest_update_time].append(
+                    cluster._get_cluster_exposition_flag())
             flat_output = []
             for timestamp in sorted(cluster_flags.keys()):
                 flat_output.extend(cluster_flags[timestamp])

--- a/src/covid19sim/frozen/clustering/simple.py
+++ b/src/covid19sim/frozen/clustering/simple.py
@@ -223,12 +223,12 @@ class SimplisticClusterManager(ClusterManagerBase):
             cluster_embeds = collections.defaultdict(list)
             for cluster in self.clusters:
                 embed = cluster.get_cluster_embedding(
-                    current_timestamp=self.latest_refresh_timestamp,
+                    current_timestamp=cluster.latest_update_time if self.generate_backw_compat_embeddings
+                    else self.latest_refresh_timestamp,
                     include_cluster_id=True,
                     old_compat_mode=self.generate_backw_compat_embeddings,
                 )
-                for msg in cluster.messages:
-                    cluster_embeds[msg.encounter_time].append([*embed, cluster.latest_update_time])
+                cluster_embeds[cluster.latest_update_time].append([*embed, cluster.latest_update_time])
             flat_output = []
             for timestamp in sorted(cluster_embeds.keys()):
                 flat_output.extend(cluster_embeds[timestamp])


### PR DESCRIPTION
Same as #145 but for develop.

Minor fixes for evaluation metrics (i.e. in the new version of Gaetan's confusion matrix) & for anyone possibly using the refactored implementation of the naive clustering algo (will return per-timestamp encounter counts instead of overall counts).