### PR TITLE
Provision for run_simu to optionally return a `City` object

### DIFF
--- a/src/covid19sim/run.py
+++ b/src/covid19sim/run.py
@@ -194,7 +194,8 @@ def run_simu(n_people=None,
              start_time=datetime.datetime(2020, 2, 28, 0, 0),
              simulation_days=10,
              outfile=None, out_chunk_size=None,
-             print_progress=False, seed=0, port=6688, n_jobs=1, other_monitors=[]):
+             print_progress=False, seed=0, port=6688, n_jobs=1, other_monitors=[],
+             return_city=False):
     """
     [summary]
 
@@ -210,6 +211,7 @@ def run_simu(n_people=None,
         port (int, optional): [description]. Defaults to 6688.
         n_jobs (int, optional): [description]. Defaults to 1.
         other_monitors (list, optional): [description]. Defaults to [].
+        return_city (bool, optional): Returns an additional city object if set to True.
 
     Returns:
         [type]: [description]
@@ -247,7 +249,10 @@ def run_simu(n_people=None,
 
     env.run(until=simulation_days * 24 * 60 / TICK_MINUTE)
 
-    return monitors, city.tracker
+    if not return_city:
+        return monitors, city.tracker
+    else:
+        return monitors, city.tracker, city
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This micro-PR adds an input argument in `run_simu` that tells it to return a `City` object in addition to the usual `monitors` and `city.tracker`. This is the only change I'll need to float the sim-in-the-loop business in `ctt`. 

Fixes #[ISSUE_NUMBER]

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
