### PR TITLE
Refactor server utils & config usage for inference (take 2, copy of #153)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,10 +27,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e '.[ctt]'
-        # Hack to have a config to use
-        git remote add ci_config https://github.com/satyaog/covid_p2p_simulation.git
-        git fetch --depth=1 ci_config ci_config
-        git checkout ci_config/ci_config -- exp/DEBUG-0/Configurations/train_config.yml
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/src/covid19sim/base.py
+++ b/src/covid19sim/base.py
@@ -440,7 +440,7 @@ class City(simpy.Environment):
             h.stores_preferences = [(compute_distance(h.household, s) + 1e-1) ** -1 for s in self.stores]
             h.parks_preferences = [(compute_distance(h.household, s) + 1e-1) ** -1 for s in self.parks]
 
-    def run(self, duration, outfile, start_time, all_possible_symptoms, port, n_jobs):
+    def run(self, duration, outfile, start_time, all_possible_symptoms):
         """
         Run the City.
         Several daily tasks take place here.
@@ -452,10 +452,6 @@ class City(simpy.Environment):
             outfile (str): may be None, the run's output file to write to
             start_time (datetime.datetime): useless arg << FIXME
             all_possible_symptoms (dict): copy of SYMPTOMS_META (config.py)
-            port (int): the port for integrated_risk_pred when updating the humans'
-                risk
-            n_jobs (int): the number of jobs for integrated_risk_pred when updating
-                the humans' risk
 
         Yields:
             simpy.Timeout
@@ -519,11 +515,9 @@ class City(simpy.Environment):
             if isinstance(self.intervention, Tracing):
                 self.intervention.update_human_risks(
                     city=self,
-                    symptoms=all_possible_symptoms,
-                    port=port,
-                    n_jobs=n_jobs,
+                    all_possible_symptoms=all_possible_symptoms,
                     data_path=outfile,
-                    COLLECT_TRAINING_DATA=self.conf.get("COLLECT_TRAINING_DATA")
+                    conf=self.conf,
                 )
                 self.tracker.track_risk_attributes(self.humans)
 

--- a/src/covid19sim/hydra-configs/base_method.yaml
+++ b/src/covid19sim/hydra-configs/base_method.yaml
@@ -8,8 +8,6 @@ simulation_days: 30
 outdir: ./output
 out_chunk_size: null
 seed: 0
-n_jobs: 1
-port: 6688
 tune: False
 name: ""
 print_progress: True
@@ -30,13 +28,9 @@ PERCENT_FOLLOW: 1.0
 P_HAS_APP: -1.0
 
 # Inference & Training
-INFECTIOUSNESS_N_DAYS_HISTORY: 14
 TRACING_N_DAYS_HISTORY: 14
-MP_BATCHSIZE: "auto"
-MP_N_JOBS: "1"
-MP_BACKEND: "loky"
 DUMP_CLUSTERS: False
-CLUSTER_TYPE: "blind" # "heuristic", "random", "graph"
+CLUSTER_ALGO_TYPE: "blind" # should be in ["old", "blind", "naive", "perfect", "simple"]
 
 UPDATES_PER_DAY: 4
 TRACE_SYMPTOMS : False

--- a/src/covid19sim/interventions.py
+++ b/src/covid19sim/interventions.py
@@ -534,24 +534,28 @@ class Tracing(object):
 
         return risk
 
-    def update_human_risks(self, **kwargs):
+    def update_human_risks(
+            self,
+            city,
+            all_possible_symptoms,
+            data_path,
+            conf,
+    ):
         """
         Updates the risk value based on the `risk_model`.
         Calls an external server if the `risk_model` relies on a machine learning server.
         """
-        city = kwargs.get("city")
-        all_possible_symptoms = kwargs.get("symptoms")
-        port = kwargs.get("port")
-        n_jobs = kwargs.get("n_jobs")
-        data_path = kwargs.get("data_path")
-        COLLECT_TRAINING_DATA = kwargs.get("COLLECT_TRAINING_DATA")
 
         if self.risk_model == "transformer":
-            all_possible_symptoms = kwargs.get("symptoms")
-            port = kwargs.get("port")
-            n_jobs = kwargs.get("n_jobs")
-            data_path = kwargs.get("data_path")
-            city.humans = integrated_risk_pred(city.humans, city.start_time, city.current_day, city.env.timestamp.hour, all_possible_symptoms, port=port, n_jobs=n_jobs, data_path=data_path, conf=city.conf)
+            city.humans = integrated_risk_pred(
+                city.humans,
+                city.start_time,
+                city.current_day,
+                city.env.timestamp.hour,
+                all_possible_symptoms,
+                data_path=data_path,
+                conf=conf,
+            )
         else:
             for human in city.humans:
                 cur_day = (human.env.timestamp - human.env.initial_timestamp).days
@@ -566,9 +570,16 @@ class Tracing(object):
 
                     human.risk_history_map[cur_day] = human.risk
 
-            if COLLECT_TRAINING_DATA:
-                city.humans = integrated_risk_pred(city.humans, city.start_time, city.current_day, city.env.timestamp.hour, all_possible_symptoms, port=port, n_jobs=n_jobs, data_path=data_path, conf=city.conf)
-
+            if conf.get("COLLECT_TRAINING_DATA"):
+                city.humans = integrated_risk_pred(
+                    city.humans,
+                    city.start_time,
+                    city.current_day,
+                    city.env.timestamp.hour,
+                    all_possible_symptoms,
+                    data_path=data_path,
+                    conf=conf,
+                )
 
     def compute_tracing_delay(self, human):
         """

--- a/src/covid19sim/models/run.py
+++ b/src/covid19sim/models/run.py
@@ -9,27 +9,18 @@ import functools
 from joblib import Parallel, delayed
 import warnings
 
-from covid19sim.utils import download_exp_data_if_not_exist
-from covid19sim.server_utils import InferenceClient, InferenceWorker
-from ctt.inference.infer import InferenceEngine
-
-def query_inference_server(params, **inf_client_kwargs):
-    """
-    [summary]
-
-    Args:
-        params ([type]): [description]
-
-    Returns:
-        [type]: [description]
-    """
-    # Make a request to the server
-    client = InferenceClient(**inf_client_kwargs)
-    results = client.infer(params)
-    return results
+from covid19sim.server_utils import InferenceClient, InferenceEngineWrapper, proc_human_batch
 
 
-def integrated_risk_pred(humans, start, current_day, time_slot, all_possible_symptoms, port=6688, n_jobs=1, data_path=None, conf={}):
+def integrated_risk_pred(
+        humans,
+        start,
+        current_day,
+        time_slot,
+        all_possible_symptoms,
+        data_path=None,
+        conf={},
+):
     """
     [summary]
     Setup and make the calls to the server
@@ -40,8 +31,6 @@ def integrated_risk_pred(humans, start, current_day, time_slot, all_possible_sym
         current_day ([type]): [description]
         time_slot ([type]): [description]
         all_possible_symptoms ([type]): [description]
-        port (int, optional): [description]. Defaults to 6688.
-        n_jobs (int, optional): [description]. Defaults to 1.
         data_path ([type], optional): [description]. Defaults to None.
         conf (dict): yaml experimental configuration
     Returns:
@@ -51,19 +40,6 @@ def integrated_risk_pred(humans, start, current_day, time_slot, all_possible_sym
     all_params = []
 
     current_time = (start + timedelta(days=current_day, hours=time_slot))
-
-    # prepare the model stuff in case we need it
-    model_exp_data_path = conf.get('TRANSFORMER_EXP_PATH')
-    if model_exp_data_path.startswith("http"):
-        assert os.path.isdir("/tmp"), "don't know where to download data to..."
-        downloaded_exp_data_path = "/tmp/temporary_exp"
-        model_exp_data_path = \
-            download_exp_data_if_not_exist(model_exp_data_path, downloaded_exp_data_path)
-        model_exp_data_path_subdirs = \
-            [os.path.join(model_exp_data_path, p) for p in os.listdir(model_exp_data_path)
-             if os.path.isdir(os.path.join(model_exp_data_path, p))]
-        assert len(model_exp_data_path_subdirs) == 1, "should only have one dir per experiment zip"
-        model_exp_data_path = model_exp_data_path_subdirs[0]
 
     for human in humans:
         if time_slot not in human.time_slots:
@@ -78,35 +54,42 @@ def integrated_risk_pred(humans, start, current_day, time_slot, all_possible_sym
             "start": start,
             "current_day": current_day,
             "all_possible_symptoms": all_possible_symptoms,
-            "COLLECT_TRAINING_DATA": conf.get('COLLECT_TRAINING_DATA'),
             "human": human_state,
             "log_path": log_path,
             "time_slot": time_slot,
-            "risk_model": conf.get('RISK_MODEL'),
-            "oracle": conf.get("USE_ORACLE"),
-            "CLUSTER_ALGO_TYPE": conf.get("CLUSTER_ALGO_TYPE")
+            "conf": conf,
         })
         human.contact_book.update_messages = []
         human.contact_book.messages = []
 
+    parallel_reqs = conf.get('INFERENCE_REQ_PARALLEL_JOBS', 16)
     if conf.get('USE_INFERENCE_SERVER'):
         batch_start_offset = 0
-        batch_size = 100  # @@@@ TODO: make this a high-level configurable arg?
+        batch_size = conf.get('INFERENCE_REQ_BATCH_SIZE', 100)
         batched_params = []
         while batch_start_offset < len(all_params):
             batch_end_offset = min(batch_start_offset + batch_size, len(all_params))
             batched_params.append(all_params[batch_start_offset:batch_end_offset])
             batch_start_offset += batch_size
-        query_func = functools.partial(query_inference_server, target_port=port)
-        with Parallel(n_jobs=n_jobs, batch_size=conf.get('MP_BATCHSIZE'), backend=conf.get('MP_BACKEND'), verbose=0, prefer="threads") as parallel:
+        parallel_reqs = max(min(parallel_reqs, len(batched_params)), 1)
+
+        def query_inference_server(params, **inf_client_kwargs):
+            # lambda used to create one socket per request (so we can request in parallel)
+            client = InferenceClient(**inf_client_kwargs)
+            return client.infer(params)
+
+        inference_frontend_address = conf.get('INFERENCE_SERVER_ADDRESS', None)
+        query_func = functools.partial(query_inference_server, server_address=inference_frontend_address)
+
+        with Parallel(n_jobs=parallel_reqs, backend="loky", prefer="threads") as parallel:
             batched_results = parallel((delayed(query_func)(params) for params in batched_params))
         results = []
         for b in batched_results:
             results.extend(b)
     else:
         # recreating an engine every time should not be too expensive... right?
-        engine = InferenceEngine(model_exp_data_path)
-        results = InferenceWorker.process_sample(all_params, engine, conf.get('MP_BACKEND'), n_jobs)
+        engine = InferenceEngineWrapper(conf.get('TRANSFORMER_EXP_PATH'))
+        results = proc_human_batch(all_params, engine, "loky", parallel_reqs)
 
     for result in results:
         if result is not None:

--- a/src/covid19sim/run.py
+++ b/src/covid19sim/run.py
@@ -167,8 +167,6 @@ def simulate(
     conf["out_chunk_size"] = out_chunk_size
     conf["print_progress"] = print_progress
     conf["seed"] = seed
-    conf["port"] = port
-    conf["n_jobs"] = n_jobs
     conf["other_monitors"] = other_monitors
 
     rng = np.random.RandomState(seed)

--- a/src/covid19sim/run.py
+++ b/src/covid19sim/run.py
@@ -76,8 +76,6 @@ def main(conf: DictConfig) -> None:
         out_chunk_size=conf["out_chunk_size"],
         print_progress=conf["print_progress"],
         seed=conf["seed"],
-        n_jobs=conf["n_jobs"],
-        port=conf["port"],
         conf=conf,
     )
 
@@ -140,8 +138,6 @@ def simulate(
     out_chunk_size=None,
     print_progress=False,
     seed=0,
-    port=6688,
-    n_jobs=1,
     other_monitors=[],
     conf={},
 ):
@@ -157,8 +153,6 @@ def simulate(
         out_chunk_size ([type], optional): [description]. Defaults to None.
         print_progress (bool, optional): [description]. Defaults to False.
         seed (int, optional): [description]. Defaults to 0.
-        port (int, optional): [description]. Defaults to 6688.
-        n_jobs (int, optional): [description]. Defaults to 1.
         other_monitors (list, optional): [description]. Defaults to [].
 
     Returns:
@@ -209,7 +203,7 @@ def simulate(
     monitors[0].join_iothread()
     # run this every hour
     env.process(
-        city.run(1440 / 24, outfile, start_time, SYMPTOMS_META_IDMAP, port, n_jobs)
+        city.run(1440 / 24, outfile, start_time, SYMPTOMS_META_IDMAP)
     )
 
     # run humans

--- a/src/covid19sim/run_experiments.sh
+++ b/src/covid19sim/run_experiments.sh
@@ -10,7 +10,7 @@ fi
 # launch simulations
 for seed in 1234 1235 1236 1237
 do
-  $PYTHON run.py tune --n_people 2000 --simulation_days 45 --seed $seed --init_percent_sick 0.001 --config configs/$1 --name $2  --outdir tune/ --n_jobs 10 &
+  $PYTHON run.py tune --n_people 2000 --simulation_days 45 --seed $seed --init_percent_sick 0.001 --config configs/$1 --name $2  --outdir tune/ &
   sleep 5;
 done
 wait;

--- a/src/covid19sim/server_bootstrap.py
+++ b/src/covid19sim/server_bootstrap.py
@@ -1,40 +1,48 @@
 """
 Entrypoint that can be used to start many inference workers on a single node.
+
+The client-server architecture should only be used for large-scale simulations
+that want to share compute resources for clustering/inference. Local tests, CI,
+and debugging sessions should avoid using the server altogether and turn it off
+via the `USE_INFERENCE_SERVER = False` setting in the experimental config.
+
+By default, if no port is specified, the server will only expect IPC-based
+requests through a file handle created in the working directory. If a port
+is specified, the server will listen for TCP connections. All internal
+communication between the broker and the workers is handled through IPC sockets.
 """
 
 import argparse
 import functools
-import os
 import signal
 import sys
 import time
 
 import covid19sim.server_utils
 
-default_port = 6688
 default_workers = 4
 default_threads = 4
-default_model_exp_path = os.path.abspath("../../exp/DEBUG-0")
+default_model_exp_path = "https://drive.google.com/file/d/1Z7g3gKh2kWFSmK2Yr19MQq0blOWS5st0"
 default_mp_backend = "loky"
 
 
 def parse_args(args=None):
     """
-    [summary]
+    Parses command line arguments for the server bootstrap main entrypoint.
 
     Args:
-        args ([type], optional): [description]. Defaults to None.
+        args: overridable arguments forwarded to argparse.
 
     Returns:
-        [type]: [description]
+        The parsed arguments.
     """
     argparser = argparse.ArgumentParser(
         description="COVID19-P2P-Transformer Inference Server Spawner",
     )
-    port_doc = f"Input port to accept connections on; will use {default_port} if not provided. "
+    port_doc = f"Input port to accept TCP connections on; will use IPC if not provided. "
     argparser.add_argument("-p", "--port", default=None, type=str, help=port_doc)
     exp_path_doc = f"Path to the experiment directory that should be used to instantiate the " \
-                   f"inference engine(s). Will use '{default_model_exp_path}' if not provided. " \
+                   f"inference engine(s). Will use Google Drive reference exp if not provided. " \
                    f"See `infer.py` for more information."
     argparser.add_argument("-e", "--exp-path", default=None, type=str, help=exp_path_doc)
     workers_doc = f"Number of inference workers to spawn. Will use {default_workers} by default."
@@ -45,51 +53,28 @@ def parse_args(args=None):
     argparser.add_argument("--mp-backend", default=None, type=int, help=mp_backend_doc)
     mp_threads_doc = f"Number of threads to spawn in each worker. Will use {default_threads} by default."
     argparser.add_argument("--mp-threads", default=None, type=int, help=mp_threads_doc)
+    weights_path_doc = "Path to the specific weights to reload inside the inference engine(s). " \
+                       "Will use the 'best checkpoint' weights if not specified."
+    argparser.add_argument("--weights-path", default=None, type=str, help=weights_path_doc)
     args = argparser.parse_args(args)
-    return args.port, args.exp_path, args.workers, args.verbose, args.mp_backend, args.mp_threads
-
-
-def validate_args(port, exp_path, workers, verbose, mp_backend, mp_threads):
-    """
-    [summary]
-
-    Args:
-        port ([type]): [description]
-        exp_path ([type]): [description]
-        workers ([type]): [description]
-        verbose ([type]): [description]
-        mp_backend ([type]): [description]
-        mp_threads ([type]): [description]
-
-    Returns:
-        [type]: [description]
-    """
-    if port is None:
-        port = default_port
-    else:
-        assert port.isdigit(), f"unexpected port number format ({port})"
-        port = int(port)
-    if exp_path is None:
-        exp_path = default_model_exp_path
-    assert os.path.isdir(exp_path), f"invalid experiment directory path: {exp_path}"
-    if workers is None:
-        workers = default_workers
-    assert workers > 0, f"invalid worker count: {workers}"
-    if mp_threads is None:
-        mp_threads = default_threads
-    assert mp_threads >= 0, f"invalid thread count: {mp_threads}"
-    return port, exp_path, workers, verbose, mp_backend, mp_threads
+    if args.port is not None:
+        assert args.port.isdigit(), f"unexpected port number format ({args.port})"
+        args.port = int(args.port)
+    if args.exp_path is None:
+        args.exp_path = default_model_exp_path
+    if args.workers is None:
+        args.workers = default_workers
+    assert args.workers > 0, f"invalid worker count: {args.workers}"
+    if args.mp_backend is None:
+        args.mp_backend = default_mp_backend
+    if args.mp_threads is None:
+        args.mp_threads = default_threads
+    assert args.mp_threads >= 0, f"invalid thread count: {args.mp_threads}"
+    return args
 
 
 def interrupt_handler(signal, frame, broker):
-    """
-    [summary]
-
-    Args:
-        signal ([type]): [description]
-        frame ([type]): [description]
-        broker ([type]): [description]
-    """
+    """Signal callback used to gently stop workers (releasing sockets) & exit."""
     print("Received SIGINT; shutting down inference worker(s) gracefully...")
     broker.stop()
     broker.join()
@@ -98,21 +83,16 @@ def interrupt_handler(signal, frame, broker):
 
 
 def main(args=None):
-    """
-    [summary]
-
-    Args:
-        args ([type], optional): [description]. Defaults to None.
-    """
-    port, exp_path, workers, verbose, mp_backend, mp_threads = \
-        validate_args(*parse_args(args))
+    """Main entrypoint; see parse_args for information on the arguments."""
+    args = parse_args(args)
     broker = covid19sim.server_utils.InferenceBroker(
-        model_exp_path=exp_path,
-        workers=workers,
-        mp_backend=mp_backend,
-        mp_threads=mp_threads,
-        port=port,
-        verbose=verbose,
+        model_exp_path=args.exp_path,
+        workers=args.workers,
+        mp_backend=args.mp_backend,
+        mp_threads=args.mp_threads,
+        port=args.port,
+        weights_path=args.weights_path,
+        verbose=args.verbose,
     )
     broker.start()
     handler = functools.partial(interrupt_handler, broker=broker)

--- a/src/covid19sim/server_utils.py
+++ b/src/covid19sim/server_utils.py
@@ -20,17 +20,20 @@ import covid19sim.frozen.clustering.base
 import covid19sim.frozen.clusters
 import covid19sim.frozen.helper
 import covid19sim.frozen.utils
+import covid19sim.utils
 
 
 expected_raw_packet_param_names = [
-    "start", "current_day", "all_possible_symptoms", "human",
-    "COLLECT_TRAINING_DATA", "log_path", "risk_model", 'time_slot', "oracle", "CLUSTER_ALGO_TYPE"
+    "start", "current_day", "all_possible_symptoms",
+    "human", "log_path", "time_slot", "conf"
 ]
 expected_processed_packet_param_names = [
     "current_day", "observed", "unobserved"
 ]
 
 default_poll_delay_ms = 500
+default_frontend_ipc_address = "ipc:///tmp/covid19sim-inference-frontend.ipc"
+default_backend_ipc_address = "ipc:///tmp/covid19sim-inference-backend.ipc"
 
 
 class AtomicCounter(object):
@@ -39,37 +42,16 @@ class AtomicCounter(object):
     """
 
     def __init__(self, init=0):
-        """
-        [summary]
-
-        Args:
-            init (int, optional): [description]. Defaults to 0.
-        """
         self._count = init
         self._lock = threading.Lock()
 
     def increment(self, delta=1):
-        """
-        [summary]
-
-        Args:
-            delta (int, optional): [description]. Defaults to 1.
-
-        Returns:
-            [type]: [description]
-        """
         with self._lock:
             self._count += delta
             return self._count
 
     @property
     def count(self):
-        """
-        [summary]
-
-        Returns:
-            [type]: [description]
-        """
         return self._count
 
 
@@ -87,21 +69,24 @@ class InferenceWorker(threading.Thread):
             identifier: typing.Any,
             mp_backend: typing.AnyStr,
             mp_threads: int,
+            weights_path: typing.Optional[typing.AnyStr] = None,
             context: typing.Optional[zmq.Context] = None,
     ):
         """
-        [summary]
+        Initializes the inference worker's attributes (counters, condvars, context).
 
         Args:
-            experiment_directory (typing.AnyStr): [description]
-            identifier (typing.Any): [description]
-            mp_backend (typing.AnyStr): [description]
-            mp_threads (int): [description]
-            context (typing.Optional[zmq.Context], optional): [description]. Defaults to None.
+            experiment_directory: the path to the experiment directory to pass to the inference engine.
+            identifier: identifier for this worker (name, used for debug purposes only).
+            mp_backend: joblib parallel backend to use when processing humans in parallel.
+            mp_threads: joblib parallel thread count to use when processing humans in parallel.
+            weights_path: the path to the specific weight file to use. If not, will use the 'best
+                checkpoint weights' inside the experiment directory.
+            context: zmq context to create i/o objects from.
         """
-
         threading.Thread.__init__(self)
         self.experiment_directory = experiment_directory
+        self.weights_path = weights_path
         self.identifier = identifier
         self.stop_flag = threading.Event()
         self.packet_counter = AtomicCounter(init=0)
@@ -114,13 +99,15 @@ class InferenceWorker(threading.Thread):
         self.init_time = None
 
     def run(self):
+        """Main loop of the inference worker thread.
+
+        Will receive brokered requests from the frontend, process them, and respond
+        with the result through the broker.
         """
-        [summary]
-        """
-        engine = InferenceEngine(self.experiment_directory)
+        engine = InferenceEngineWrapper(self.experiment_directory, self.weights_path)
         socket = self.context.socket(zmq.REQ)
         socket.identity = str(self.identifier).encode("ascii")
-        socket.connect("ipc://backend.ipc")
+        socket.connect(default_backend_ipc_address)
         socket.send(b"READY")  # tell broker we're ready
         poller = zmq.Poller()
         poller.register(socket, zmq.POLLIN)
@@ -130,9 +117,8 @@ class InferenceWorker(threading.Thread):
             if socket in evts and evts[socket] == zmq.POLLIN:
                 proc_start_time = time.time()
                 address, empty, buffer = socket.recv_multipart()
-                hdi = pickle.loads(buffer)
-                response = self.process_sample(
-                    hdi, engine, self.mp_backend, self.mp_threads)
+                sample = pickle.loads(buffer)
+                response = proc_human_batch(sample, engine, self.mp_backend, self.mp_threads)
                 response = pickle.dumps(response)
                 socket.send_multipart([address, b"", response])
                 self.time_counter.increment(time.time() - proc_start_time)
@@ -140,80 +126,28 @@ class InferenceWorker(threading.Thread):
         socket.close()
 
     def get_processed_count(self):
-        """
-        Returns the total number of processed requests by this inference server.
-
-        Returns:
-            [type]: [description]
-        """
+        """Returns the total number of processed requests by this inference server."""
         return self.packet_counter.count
 
     def get_averge_processing_delay(self):
-        """
-        Returns the average sample processing time between reception & response (in seconds).
-
-        Returns:
-            [type]: [description]
-        """
+        """Returns the average sample processing time between reception & response (in seconds)."""
         tot_delay, tot_packet_count = self.time_counter.count, self.packet_counter.count
         if not tot_packet_count:
             return float("nan")
         return tot_delay / self.packet_counter.count
 
     def get_processing_uptime(self):
-        """
-        Returns the fraction of total uptime that the server spends processing requests.
-
-        Returns:
-            [type]: [description]
-        """
+        """Returns the fraction of total uptime that the server spends processing requests."""
         tot_process_time, tot_time = self.time_counter.count, time.time() - self.init_time
         return tot_process_time / tot_time
 
     def stop(self):
-        """
-        Stops the infinite data reception loop, allowing a clean shutdown.
-        """
+        """Stops the infinite data reception loop, allowing a clean shutdown."""
         self.stop_flag.set()
-
-    @staticmethod
-    def process_sample(sample, engine, mp_backend=None, mp_threads=0):
-        """
-        [summary]
-
-        Args:
-            sample ([type]): [description]
-            engine ([type]): [description]
-            mp_backend ([type], optional): [description]. Defaults to None.
-            mp_threads (int, optional): [description]. Defaults to 0.
-
-        Returns:
-            [type]: [description]
-        """
-        if isinstance(sample, list):
-            if mp_threads > 0:
-                import joblib
-                with joblib.Parallel(
-                        n_jobs=mp_threads,
-                        backend=mp_backend,
-                        batch_size="auto",
-                        prefer="threads") as parallel:
-                    results = parallel((joblib.delayed(proc_human)(human, engine) for human in sample))
-                return [(r['name'], r['risk_history'], r['clusters']) for r in results]
-            else:
-                return [InferenceWorker.process_sample(human, engine, mp_backend, mp_threads) for human in sample]
-        else:
-            assert isinstance(sample, dict), "unexpected input data format"
-            results = proc_human(sample, engine)
-            if results is not None:
-                return (results['name'], results['risk_history'], results['clusters'])
-            return None
 
 
 class InferenceBroker(threading.Thread):
-    """
-    Manages inference workers through a backend connection for load balancing.
-    """
+    """Manages inference workers through a backend connection for load balancing."""
 
     def __init__(
             self,
@@ -221,23 +155,24 @@ class InferenceBroker(threading.Thread):
             workers: int,
             mp_backend: typing.AnyStr,
             mp_threads: int,
-            port: int,
+            port: typing.Optional[int] = None,
             verbose: bool = False,
             verbose_print_delay: float = 5.,
+            weights_path: typing.Optional[typing.AnyStr] = None,
             context: typing.Optional[zmq.Context] = None,
     ):
         """
-        [summary]
+        Initializes the inference broker's attributes (counters, condvars, context).
 
         Args:
-            model_exp_path (typing.AnyStr): [description]
-            workers (int): [description]
-            mp_backend (typing.AnyStr): [description]
-            mp_threads (int): [description]
-            port (int): [description]
-            verbose (bool, optional): [description]. Defaults to False.
-            verbose_print_delay (float, optional): [description]. Defaults to 5..
-            context (typing.Optional[zmq.Context], optional): [description]. Defaults to None.
+            model_exp_path: the path to the experiment directory to pass to the inference engine.
+            workers: the number of independent inference workers to spawn to process requests.
+            mp_backend: joblib parallel backend to use when processing humans in parallel.
+            mp_threads: joblib parallel thread count to use when processing humans in parallel.
+            port: the port number to accept TCP requests on. If None, will accept IPC requests instead.
+            verbose: toggles whether to print extra debug information while running.
+            verbose_print_delay: specifies how often the extra debug info should be printed.
+            context: zmq context to create i/o objects from.
         """
         threading.Thread.__init__(self)
         if context is None:
@@ -248,19 +183,28 @@ class InferenceBroker(threading.Thread):
         self.mp_threads = mp_threads
         self.port = port
         self.model_exp_path = model_exp_path
+        self.weights_path = weights_path
         self.stop_flag = threading.Event()
         self.verbose = verbose
         self.verbose_print_delay = verbose_print_delay
 
     def run(self):
+        """Main loop of the inference broker thread.
+
+        Will received requests from clients and dispatch them to available workers.
         """
-        [summary]
-        """
-        print(f"Initializing {self.workers} worker(s) from directory: {self.model_exp_path}")
+        print(f"Initializing {self.workers} worker(s) from experiment: {self.model_exp_path}")
+        if self.weights_path is not None:
+            print(f"\t will use weights directly from: {self.weights_path}")
         frontend = self.context.socket(zmq.ROUTER)
-        frontend.bind(f"tcp://*:{self.port}")
+        if self.port:
+            frontend_address = f"tcp://*:{self.port}"
+        else:
+            frontend_address = default_frontend_ipc_address
+        print(f"Will listen for inference requests at: {frontend_address}")
+        frontend.bind(frontend_address)
         backend = self.context.socket(zmq.ROUTER)
-        backend.bind("ipc://backend.ipc")
+        backend.bind(default_backend_ipc_address)
         worker_map = {}
         for worker_idx in range(self.workers):
             worker_id = f"worker:{worker_idx}"
@@ -269,6 +213,7 @@ class InferenceBroker(threading.Thread):
                 worker_id,
                 self.mp_backend,
                 self.mp_threads,
+                weights_path=self.weights_path,
                 context=self.context
             )
             worker_map[worker_id] = worker
@@ -297,7 +242,8 @@ class InferenceBroker(threading.Thread):
                     packets = worker.get_processed_count()
                     delay = worker.get_averge_processing_delay()
                     uptime = worker.get_processing_uptime()
-                    print(f"  {worker_id}:  packets={packets}  avg_delay={delay:.6f}sec  proc_time_ratio={uptime:.1%}")
+                    print(f"  {worker_id}:  packets={packets}"
+                          f"  avg_delay={delay:.6f}sec  proc_time_ratio={uptime:.1%}")
                 last_update_timestamp = time.time()
         for w in worker_map.values():
             w.stop()
@@ -321,82 +267,107 @@ class InferenceClient:
 
     def __init__(
             self,
-            target_port: typing.Union[int, typing.List[int]],
-            target_addr: typing.Union[str, typing.List[str]] = "localhost",
+            server_address: typing.Optional[typing.AnyStr] = default_frontend_ipc_address,
             context: typing.Optional[zmq.Context] = None,
     ):
         """
-        [summary]
+        Initializes the client's attributes (socket, context).
 
         Args:
-            target_port (typing.Union[int, typing.List[int]]): [description]
-            target_addr (typing.Union[str, typing.List[str]], optional): [description]. Defaults to "localhost".
-            context (typing.Optional[zmq.Context], optional): [description]. Defaults to None.
+            server_address: address of the inference server frontend to send requests to.
+            context: zmq context to create i/o objects from.
         """
-        self.target_ports = [target_port] if isinstance(target_port, int) else target_port
-        self.target_addrs = [target_addr] if isinstance(target_addr, str) else target_addr
-        if len(self.target_ports) != len(self.target_addrs):
-            assert len(self.target_addrs) == 1 and len(self.target_ports) > 1, \
-                "must either match all ports to one address or provide full port/addr combos"
-            self.target_addrs = self.target_addrs * len(self.target_ports)
         if context is None:
             context = zmq.Context()
         self.context = context
         self.socket = self.context.socket(zmq.REQ)
-        for addr, port in zip(self.target_addrs, self.target_ports):
-            self.socket.connect(f"tcp://{addr}:{port}")
+        if server_address is None:
+            server_address = default_frontend_ipc_address
+        self.socket.connect(server_address)
 
     def infer(self, sample):
-        """
-        Forwards a data sample for the inference engine using pickle.
-
-        Args:
-            sample ([type]): [description]
-
-        Returns:
-            [type]: [description]
-        """
-        self.socket.send(pickle.dumps(sample))
-        return pickle.loads(self.socket.recv())
+        """Forwards a data sample for the inference engine using pickle."""
+        self.socket.send_pyobj(sample)
+        return self.socket.recv_pyobj()
 
 
-def proc_human(params, inference_engine=None):
+class InferenceEngineWrapper(InferenceEngine):
+    """Inference engine wrapper used to download & extract experiment data, if necessary."""
+
+    def __init__(self, experiment_directory, *args, **kwargs):
+        if experiment_directory.startswith("http"):
+            assert os.path.isdir("/tmp"), "don't know where to download data to..."
+            experiment_root_directory = \
+                covid19sim.utils.download_exp_data_if_not_exist(experiment_directory, "/tmp")
+            experiment_subdirectories = \
+                [os.path.join(experiment_root_directory, p) for p in os.listdir(experiment_root_directory)
+                 if os.path.isdir(os.path.join(experiment_root_directory, p))]
+            assert len(experiment_subdirectories) == 1, "should only have one dir per experiment zip"
+            experiment_directory = experiment_subdirectories[0]
+        super().__init__(experiment_directory, *args, **kwargs)
+
+
+def proc_human_batch(
+        sample,
+        engine,
+        mp_backend,
+        mp_threads,
+):
     """
-    (Pre-)Processes the received simulator data for a single human.
+    Processes a chunk of human data, clustering messages and computing new risk levels.
 
     Args:
-        params ([type]): [description]
-        inference_engine ([type], optional): [description]. Defaults to None.
+        sample: a dictionary of data necessary for clustering+inference.
+        engine: the inference engine, pre-instantiated with the right experiment config.
+        mp_backend: joblib parallel backend to use when processing humans in parallel.
+        mp_threads: joblib parallel thread count to use when processing humans in parallel.
 
     Returns:
-        [type]: [description]
+        The clustering + risk level update results.
     """
-    if all([p in params for p in expected_processed_packet_param_names]):
-        return params, None  # probably fetching data from data loader; skip stuff below
+    if isinstance(sample, list):
+        if mp_threads > 0:
+            import joblib
+            with joblib.Parallel(
+                    n_jobs=mp_threads,
+                    backend=mp_backend,
+                    batch_size="auto",
+                    prefer="threads") as parallel:
+                results = parallel((joblib.delayed(_proc_human)(human, engine) for human in sample))
+            return [(r['name'], r['risk_history'], r['clusters']) for r in results]
+        else:
+            return [proc_human_batch(human, engine, mp_backend, mp_threads) for human in sample]
+    else:
+        assert isinstance(sample, dict), "unexpected input data format"
+        results = _proc_human(sample, engine)
+        if results is not None:
+            return (results['name'], results['risk_history'], results['clusters'])
+        return None
 
+
+def _proc_human(params, inference_engine):
+    """Internal implementation of the `proc_human_batch` function."""
     assert isinstance(params, dict) and \
-           all([p in params for p in expected_raw_packet_param_names]), \
-        "unexpected/broken proc_human input format between simulator and inference service"
+        all([p in params for p in expected_raw_packet_param_names]), \
+        "unexpected/broken _proc_human input format between simulator and inference service"
+    conf = params["conf"]
 
     # Cluster Messages
-    CLUSTER_ALGO_TYPE = params["CLUSTER_ALGO_TYPE"] # see yml config
-    # TODO: put algo type def above in config file
+    cluster_algo_type = conf.get("CLUSTER_ALGO_TYPE")
     human = params["human"]
-    if CLUSTER_ALGO_TYPE == "old":
+    if cluster_algo_type == "old":
         human["clusters"].add_messages(human["messages"])
         human["clusters"].update_records(human["update_messages"])
         human["clusters"].purge(params["current_day"])
     else:
-        # note: this arg should only be true if the sim keeps sending old messages every iteration
-        REBUILD_CLUSTERS_FROM_SCRATCH = False  # TODO: put in config file
-        if REBUILD_CLUSTERS_FROM_SCRATCH or \
-                not isinstance(human["clusters"], covid19sim.frozen.clustering.base.ClusterManagerBase):
-            clustering_type = covid19sim.frozen.clustering.base.get_cluster_manager_type(CLUSTER_ALGO_TYPE)
-            if CLUSTER_ALGO_TYPE == "naive":
+        if not isinstance(human["clusters"], covid19sim.frozen.clustering.base.ClusterManagerBase):
+            clustering_type = \
+                covid19sim.frozen.clustering.base.get_cluster_manager_type(cluster_algo_type)
+            if cluster_algo_type == "naive":
                 clustering_type = functools.partial(clustering_type, ticks_per_uid_roll=1)
             # note: we create the manager to use day-level timestamps only
             human["clusters"] = clustering_type(
-                max_history_ticks_offset=14, # TODO: we should pass this value in as an argument instead of a magic number (num days history)
+                max_history_ticks_offset=conf.get("TRACING_N_DAYS_HISTORY"),
                 # note: the simulator should be able to match all update messages to encounters, but
                 # since the time slot update voodoo, I (PLSC) have not been able to make no-adopt
                 # version of the naive implementation work (both with and without batching)
@@ -406,32 +377,15 @@ def proc_human(params, inference_engine=None):
             )
         # set the current day as the refresh timestamp to auto-purge outdated messages in advance
         human["clusters"].set_current_timestamp(params["current_day"])
-        USE_MESSAGE_BATCHING = True  # TODO: put in config file
-        if USE_MESSAGE_BATCHING:
-            encounter_messages = covid19sim.frozen.utils.convert_messages_to_batched_new_format(
-                human["messages"], human["exposure_message"])
-            update_messages = covid19sim.frozen.utils.convert_messages_to_batched_new_format(
-                human["update_messages"])
-            earliest_new_encounter_message = encounter_messages[0][0] if len(encounter_messages) else None
-        else:
-            encounter_messages = \
-                [covid19sim.frozen.utils.convert_message_to_new_format(m) for m in human["messages"]]
-            exposure_message = \
-                covid19sim.frozen.utils.convert_message_to_new_format(human["exposure_message"]) \
-                if human["exposure_message"] else None
-            # since the original messages do not carry the 'exposition' flag, we have to set it manually:
-            # hopefully this will only match the proper messages (based on _real_sender_id comparisons)...
-            if exposure_message is not None:
-                for m in encounter_messages:
-                    m._exposition_event = m == exposure_message
-            update_messages = \
-                [covid19sim.frozen.utils.convert_message_to_new_format(m) for m in human["update_messages"]]
-            earliest_new_encounter_message = encounter_messages[0] if len(encounter_messages) else None
+        encounter_messages = covid19sim.frozen.utils.convert_messages_to_batched_new_format(
+            human["messages"], human["exposure_message"])
+        update_messages = covid19sim.frozen.utils.convert_messages_to_batched_new_format(
+            human["update_messages"])
+        earliest_new_encounter_message = encounter_messages[0][0] if len(encounter_messages) else None
         if earliest_new_encounter_message is not None:
             # quick verification: even with a 1-day buffer for timeslot craziness, we should not be
             # getting old encounters here; the simulator should not keep & transfer those every call
-            assert REBUILD_CLUSTERS_FROM_SCRATCH or \
-                   earliest_new_encounter_message.encounter_time + 1 >= params["current_day"]
+            assert earliest_new_encounter_message.encounter_time + 1 >= params["current_day"]
         human["clusters"].add_messages(
             messages=[*encounter_messages, *update_messages],
             current_timestamp=params["current_day"],
@@ -469,32 +423,29 @@ def proc_human(params, inference_engine=None):
         }
     }
 
-    if params["COLLECT_TRAINING_DATA"]:
+    if conf.get("COLLECT_TRAINING_DATA"):
         os.makedirs(params["log_path"], exist_ok=True)
         with open(os.path.join(params["log_path"], f"daily_human-{params['time_slot']}.pkl"), 'wb') as fd:
             pickle.dump(daily_output, fd)
 
-    # Return ground truth infectiousnesses
-    if params.get('oracle', None):
+    if conf.get("USE_ORACLE"):
+        # return ground truth infectiousnesses
         human['risk_history'] = human['infectiousnesses']
-        return human
-    inference_result = None
-    if params['risk_model'] == "transformer":
-        try:
-            inference_result = inference_engine.infer(daily_output)
-        except InvalidSetSize:
-            pass  # return None for invalid samples
-        except RuntimeError as error:
-            # TODO: ctt.modules.HealthHistoryEmbedding can fail with :
-            #  size mismatch, m1: [14 x 29], m2: [13 x 128]
-            warnings.warn(str(error), RuntimeWarning)
-    human['risk_history'] = None
-    if inference_result is not None:
-        # @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-        # ... TODO: apply the inference results to the human's risk before returning it
-        #           (it will depend on the output format used by Nasim)
-        # @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-        human['risk_history'] = inference_result['infectiousness']
+    else:
+        # estimate infectiousnesses using CTT inference engine
+        inference_result = None
+        if conf.get("RISK_MODEL") == "transformer":
+            try:
+                inference_result = inference_engine.infer(daily_output)
+            except InvalidSetSize:
+                pass  # return None for invalid samples
+            except RuntimeError as error:
+                # TODO: ctt.modules.HealthHistoryEmbedding can fail with :
+                #  size mismatch, m1: [14 x 29], m2: [13 x 128]
+                warnings.warn(str(error), RuntimeWarning)
+        human['risk_history'] = None
+        if inference_result is not None:
+            human['risk_history'] = inference_result['infectiousness']
 
     # clear all messages for next time we update
     human["messages"] = []

--- a/src/covid19sim/utils.py
+++ b/src/covid19sim/utils.py
@@ -1587,21 +1587,23 @@ def download_exp_data_if_not_exist(
 
     Args:
         exp_data_url: the zip URL (under the `https://drive.google.com/file/d/ID` format).
-        exp_data_destination: where to save the model data.
+        exp_data_destination: where to extract the model data.
 
     Returns:
         The path to the model data.
     """
     assert exp_data_url.startswith("https://drive.google.com/file/d/")
-    if os.path.exists(exp_data_destination):
-        return exp_data_destination
-    os.makedirs(exp_data_destination)
     gdrive_file_id = exp_data_url.split("/")[-1]
-    zip_destination = os.path.join(exp_data_destination, f"{gdrive_file_id}.zip")
-    zip_path = download_file_from_google_drive(gdrive_file_id, zip_destination)
-    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-        zip_ref.extractall(exp_data_destination)
-    return exp_data_destination
+    output_data_path = os.path.join(exp_data_destination, gdrive_file_id)
+    downloaded_zip_path = os.path.join(exp_data_destination, f"{gdrive_file_id}.zip")
+    if os.path.isfile(downloaded_zip_path) and os.path.isdir(output_data_path):
+        return output_data_path
+    os.makedirs(output_data_path, exist_ok=True)
+    zip_path = download_file_from_google_drive(gdrive_file_id, downloaded_zip_path)
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        zip_ref.extractall(output_data_path)
+    return output_data_path
+
 
 def extract_tracker_data(tracker, conf):
     """

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,11 +1,10 @@
 import unittest.mock
 
 import covid19sim.server_utils
+import covid19sim.server_bootstrap
 
 
 class ServerTests(unittest.TestCase):
-
-    EXPERIMENT_DATA_URL = "https://drive.google.com/file/d/1Z7g3gKh2kWFSmK2Yr19MQq0blOWS5st0"
 
     @staticmethod
     def fake_proc_human_batch(sample, *args, **kwargs):
@@ -13,7 +12,7 @@ class ServerTests(unittest.TestCase):
 
     def test_inference(self):
         manager = covid19sim.server_utils.InferenceBroker(
-            model_exp_path=self.EXPERIMENT_DATA_URL,
+            model_exp_path=covid19sim.server_bootstrap.default_model_exp_path,
             workers=2,
             mp_backend="loky",
             mp_threads=4,

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,78 +1,34 @@
-import numpy as np
-import unittest
+import unittest.mock
 
-import ctt.inference.infer
-import ctt.data_loading
 import covid19sim.server_utils
 
-"""@@@@@@@@PLSC fix this one -- it's outdated"""
-# class Tests(unittest.TestCase):
-#
-#     DATASET_PATH = "data/1k-1-output"
-#     EXPERIMENT_PATH = "exp/DEBUG-0"
-#     NUM_KEYS_IN_BATCH = 15
-#
-#     def test_inference(self):
-#         manager = covid19sim.server_utils.InferenceBroker(
-#             model_exp_path=self.EXPERIMENT_PATH,
-#             workers=2,
-#             mp_backend="loky",
-#             mp_threads=4,
-#             port=6688,
-#             verbose=False,
-#         )
-#         manager.start()
-#         local_engine = ctt.inference.infer.InferenceEngine(self.EXPERIMENT_PATH)
-#         remote_engine = covid19sim.server_utils.InferenceClient(6688, "localhost")
-#         import pdb; pdb.set_trace()
-#
-#         dataset = ctt.data_loading.loader.ContactDataset(self.DATASET_PATH)
-#         for _ in range(1000):
-#             hdi, local_output = None, None
-#             try:
-#                 hdi = dataset.read(
-#                     np.random.randint(dataset.num_humans),
-#                     np.random.randint(dataset.num_days),
-#                 )
-#                 local_output = local_engine.infer(hdi)
-#             except ctt.data_loading.loader.InvalidSetSize:
-#                 pass  # skip samples without encounters
-#             # avoid sending a bad sample to remote server
-#             remote_output = remote_engine.infer(hdi)
-#             if local_output is None:
-#                 self.assertTrue(remote_output is None)
-#             # TODO: test below is pretty useless until we figure out the output
-#             #if local_output is not None:
-#             if local_output is not None and remote_output is not None:
-#                 for output in [local_output, remote_output]:
-#                     self.assertIsInstance(output, dict)
-#                     self.assertEqual(len(output), 2)
-#                     self.assertIn("contagion_proba", output)
-#                     self.assertIn("infectiousness", output)
-#                     self.assertIsInstance(output["contagion_proba"], np.ndarray)
-#                     self.assertIsInstance(output["infectiousness"], np.ndarray)
-#                 self.assertEqual(
-#                     local_output["contagion_proba"].shape,
-#                     remote_output["contagion_proba"].shape,
-#                 )
-#                 self.assertEqual(
-#                     local_output["infectiousness"].shape,
-#                     remote_output["infectiousness"].shape,
-#                 )
-#                 # self.assertTrue(
-#                 #     np.isclose(
-#                 #         local_output["contagion_proba"],
-#                 #         remote_output["contagion_proba"],
-#                 #     ).all()
-#                 # )
-#                 # self.assertTrue(
-#                 #     np.isclose(
-#                 #         local_output["infectiousness"], remote_output["infectiousness"]
-#                 #     ).all()
-#                 # )
-#         manager.stop()
-#         manager.join()
-#
-#
-# if __name__ == "__main__":
-#     unittest.main()
+
+class ServerTests(unittest.TestCase):
+
+    EXPERIMENT_DATA_URL = "https://drive.google.com/file/d/1Z7g3gKh2kWFSmK2Yr19MQq0blOWS5st0"
+
+    @staticmethod
+    def fake_proc_human_batch(sample, *args, **kwargs):
+        return sample
+
+    def test_inference(self):
+        manager = covid19sim.server_utils.InferenceBroker(
+            model_exp_path=self.EXPERIMENT_DATA_URL,
+            workers=2,
+            mp_backend="loky",
+            mp_threads=4,
+            verbose=False,
+        )
+        manager.start()
+        remote_engine = covid19sim.server_utils.InferenceClient()
+        with unittest.mock.patch("covid19sim.server_utils.proc_human_batch") as mock:
+            mock.side_effect = self.fake_proc_human_batch
+            for test_idx in range(100):
+                remote_output = remote_engine.infer(test_idx)
+                self.assertEqual(remote_output, test_idx)
+        manager.stop()
+        manager.join()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_configs/naive_local.yaml
+++ b/tests/test_configs/naive_local.yaml
@@ -20,13 +20,9 @@ GLOBAL_MOBILITY_SCALING_FACTOR : 1
 CLUSTER_PATH : "output/clusters.json"
 
 # Inference & Training
-INFECTIOUSNESS_N_DAYS_HISTORY : 14
 TRACING_N_DAYS_HISTORY : 14
-MP_BATCHSIZE : "auto"
-MP_N_JOBS : "1"
-MP_BACKEND : "loky"
 DUMP_CLUSTERS : False
-CLUSTER_TYPE : "heuristic" # "random", "graph"
+CLUSTER_ALGO_TYPE: "blind" # "old", "blind", "naive", "perfect", "simple"
 
 # TRACING RISK MODEL PARAMETERS  (non-ML)
 TRACE_SYMPTOMS : True

--- a/tests/test_configs/naive_local.yaml
+++ b/tests/test_configs/naive_local.yaml
@@ -22,7 +22,7 @@ CLUSTER_PATH : "output/clusters.json"
 # Inference & Training
 TRACING_N_DAYS_HISTORY : 14
 DUMP_CLUSTERS : False
-CLUSTER_ALGO_TYPE: "blind" # "old", "blind", "naive", "perfect", "simple"
+CLUSTER_ALGO_TYPE: "blind" # should be in ["old", "blind", "naive", "perfect", "simple"]
 
 # TRACING RISK MODEL PARAMETERS  (non-ML)
 TRACE_SYMPTOMS : True

--- a/tests/test_configs/test_covid_testing.yaml
+++ b/tests/test_configs/test_covid_testing.yaml
@@ -19,13 +19,9 @@ P_HAS_APP: -1.0 # add 10% of the target adoption rate
 CLUSTER_PATH: "output/clusters"
 
 # Inference & Training
-INFECTIOUSNESS_N_DAYS_HISTORY: 14
 TRACING_N_DAYS_HISTORY: 14
-MP_BATCHSIZE: "auto"
-MP_N_JOBS: "1"
-MP_BACKEND: "loky"
 DUMP_CLUSTERS: False
-CLUSTER_TYPE: "heuristic" # "random", "graph"
+CLUSTER_ALGO_TYPE: "blind" # should be in ["old", "blind", "naive", "perfect", "simple"]
 
 # TRACING RISK MODEL PARAMETERS  (non-ML)
 TRACE_SYMPTOMS: False

--- a/tests/test_configs/test_models.yaml
+++ b/tests/test_configs/test_models.yaml
@@ -22,11 +22,7 @@ CLUSTER_PATH : "output/clusters"
 TRANSFORMER_EXP_PATH : "https://drive.google.com/file/d/1Z7g3gKh2kWFSmK2Yr19MQq0blOWS5st0"
 
 # Inference & Training
-INFECTIOUSNESS_N_DAYS_HISTORY : 14
 TRACING_N_DAYS_HISTORY : 14
-MP_BATCHSIZE : "auto"
-MP_N_JOBS : "1"
-MP_BACKEND : "loky"
 DUMP_CLUSTERS : False
 CLUSTER_ALGO_TYPE : "blind" # should be in ["old", "blind", "naive", "perfect", "simple"]
 

--- a/tests/test_functional_seniors_residence.py
+++ b/tests/test_functional_seniors_residence.py
@@ -83,11 +83,7 @@ def test_functional_seniors_residence():
         monitors[0].dump()
         monitors[0].join_iothread()
 
-        env.process(
-            city.run(
-                1440 / 24, outfile, start_time, SYMPTOMS_META_IDMAP, port=668, n_jobs=1
-            )
-        )
+        env.process(city.run(1440/24, outfile, start_time, SYMPTOMS_META_IDMAP))
 
         for human in city.humans:
             env.process(human.run(city=city))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,8 +31,8 @@ class ModelsTest(unittest.TestCase):
                 init_percent_sick=0.1,
                 outfile=os.path.join(d, "output"),
                 out_chunk_size=1,
-                seed=0, n_jobs=12,
-                port=6688, conf=conf
+                seed=0,
+                conf=conf,
             )
             days_output = glob.glob(f"{d}/daily_outputs/*/")
             days_output.sort(key=lambda p: int(p.split(os.path.sep)[-2]))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -271,11 +271,9 @@ def start_inference_server():
     Returns:
         [type]: [description]
     """
-    exp_dir = os.path.join(os.path.dirname(__file__), "exp/DEBUG-0")
-    p = Process(target=covid19sim.server_bootstrap.main, args=([f"-e{exp_dir}"],), daemon=True)
+    p = Process(target=covid19sim.server_bootstrap.main, daemon=True)
     p.start()
     return p
-
 
 
 def get_test_conf(conf_name):


### PR DESCRIPTION
This is a copy of #153 which was closed due to hella-bugs.

NOTE: As of 2020/05/18-2100, this branch is fully rebased on #158 --- that one MUST be merged into experimental first.

Overview of changes:

Deleted all port/n_jobs args being forwarded around, moved to exp config;
Cleaned up unused config settings (batchsize, infect hist, backend, ...);
Added cluster type setting to experimental config (replaced unused one);
Added config path forwarding to server utils (params) instead of flags;
Fixed broken test_server with mocked packet processor for networking;
Cleaned up experimental gdrive data download via engine wrapper;
Added proper default config path to simulation (main) runner;
Updated run_simu to return city obj (for Nasim's sim-in-loop);
Cleaned up server bootstrap script default args checks;
Updated inference broker to use IPC frontend by default.